### PR TITLE
Pin to a particular commit for the PX Web support.

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/dougmet/yamlmd
-git+https://github.com/open-sdg/sdg-build@pxweb-support-revamp
+git+https://github.com/open-sdg/sdg-build@d5f20cf5b923fdde010b9afe1f73d89cf1284c73
 frictionless==4.40.8
 pydantic==1.*


### PR DESCRIPTION
This is to ensure that any future changes to the experimental pxweb-support-revamp branch do not cause problems with the production site.